### PR TITLE
New module intp

### DIFF
--- a/ASTHelpers.fs
+++ b/ASTHelpers.fs
@@ -2,6 +2,7 @@ namespace Zorx
 
 
 open Zorx.Frontend.AST
+open Zorx.Interpreter
 
 module ASTHelpers =
 
@@ -56,8 +57,8 @@ module ASTHelpers =
                     | Lt -> PrimTyp.Boolean
                     | Leq -> PrimTyp.Boolean
                     | Geq -> PrimTyp.Boolean
-                    | Neq -> ptyp1
-                    | Eq -> ptyp1
+                    | Neq -> PrimTyp.Boolean
+                    | Eq -> PrimTyp.Boolean
                     | Plus -> Integer
                     | Minus -> Integer
                     | And -> PrimTyp.Boolean
@@ -65,3 +66,19 @@ module ASTHelpers =
             | UExp (_, op) ->
                 match op with
                     | Not -> PrimTyp.Boolean
+
+    // Only works for reasonable variables and values.
+    // Long variables/huge values will not look pretty.
+    let prettyPrintRun run =
+        match List.tryHead run with
+            | Some h -> 
+                List.iter (fun (key, _) -> printf "%A   " key) h
+                printfn ""
+                List.iter (fun l ->
+                    List.iter (fun item ->
+                        let (_,value) = item
+                        printf "|%A|\t" value
+                    ) l
+                    printf "\n"
+                ) run
+            | None -> ()

--- a/ASTIntp.fs
+++ b/ASTIntp.fs
@@ -226,7 +226,7 @@ module Interpreter =
                     let dpEnv = addInputVectorToEnv cycleInput dpEnv
                     let ctrlEnv = addInputVectorToEnv ctrlInCycle ctrlEnv
                     let (nextState, nextEnv, nextCtrlEnv) = transitionSystem (state, dpEnv, ctrlEnv)
-                    let cycleOutput = (mapToList nextEnv) @ (mapToList nextCtrlEnv)
+                    let cycleOutput = (mapToList nextEnv)
                     logger "Cycle-----"
                     inner nextState (nextEnv, nextCtrlEnv) (rest, restCtrlIn) (cycleOutput::runVector)
                 | _ -> failwith "Different input length is not allowed."

--- a/Lexer.fsl
+++ b/Lexer.fsl
@@ -72,7 +72,6 @@ rule tokenize = parse
   | "-"         { lexerLogger "Lexer read MINUS"; MINUS }
   | "+"         { lexerLogger "Lexer read PLUS"; PLUS }
   | ";"         { lexerLogger "Lexer read SEMICOLON"; SEMICOLON }
-  // | comment     { tokenize lexbuf }
   | identifier  { lexerLogger (sprintf "Lexer read keyword:  %A" keyword(Encoding.UTF8.GetString(lexbuf.Lexeme)))
                   keyword(Encoding.UTF8.GetString(lexbuf.Lexeme)) }
   | eof         { lexerLogger "Lexer read eof"; EOF }

--- a/Parser.fsy
+++ b/Parser.fsy
@@ -45,7 +45,8 @@ Module:
         {
             let mControllerDecls = $4
             let mDpDecls = $7
-            printfn "%A" mControllerDecls
+            logger (sprintf "parsed controller decls: %A" mControllerDecls)
+            logger (sprintf "parsed dp decls: %A" mDpDecls)
             let (Controller (controllerDecls, transitions)) = $11
             let (Datapath (dpDecls, actions)) = $10
             let controller = Controller (controllerDecls @ mControllerDecls, transitions)

--- a/main.fsx
+++ b/main.fsx
@@ -27,7 +27,7 @@ let (S ms) = ast
 match ms with
     | [] -> failwith "Empty fsmd"
     | m::ms ->
-        let (M (name, fsm, dp)) = m
+//         let (M (name, fsm, dp)) = m
         // let (Fsm (decL, tL)) = fsm
         // match tL with
         //     | [] -> failwith "Empty transition list"
@@ -169,3 +169,37 @@ match newModuleSpec with
     | m::newModuleSpec ->
         let (M (name, fsm, dp)) = m
         printfn "%A" (tcModule m)
+printfn "ELEVATOR:\n\n"
+let elevatorAST = parseFromFile "test/elevator.zorx"
+let (S elevatorSpec) = elevatorAST
+match elevatorSpec with
+    | [] -> failwith "Empty fsmd"
+    | m::_ ->
+        let (M (moduleName, _, _)) = m
+        printfn "typcheck of %A passing: %A" moduleName (tcModule m)
+        let ctrlIn = [
+            [("floorReq", B true)];
+            [("floorReq", B true)];
+            [("floorReq", B true)];
+
+            [("floorReq", B true)];
+            [("floorReq", B true)];
+            [("floorReq", B true)];
+        ]
+        let dpIn = [
+            [("floorReqN", N 2)];
+            [("floorReqN", N 3)];
+            [("floorReqN", N 1)];
+
+            [("floorReqN", N 3)];
+            [("floorReqN", N 1)];
+            [("floorReqN", N 2)];
+        ]
+
+        let condFunc (env: VarEnv) =
+            env.["readyForInput"] = B true
+
+        let testRun = execWithCondition m "init" dpIn ctrlIn condFunc
+
+        prettyPrintRun testRun
+        prettyPrintRun []

--- a/main.fsx
+++ b/main.fsx
@@ -70,17 +70,23 @@ match ms with
         // printfn "%A, %A \n\n" s3 ctx3
 
         // Testing runner function.
-        let inputVector = [
-            [("cIn", B true); ("dpIn", N 3)];
-            [("cIn", B true); ("dpIn", N 5)];
-            [("cIn", B true); ("dpIn", N 4)];
-            [("cIn", B false); ("dpIn", N 5)];
+        let dpIn = [
+            [("dpIn", N 3)];
+            [("dpIn", N 5)];
+            [("dpIn", N 4)];
+            [("dpIn", N 5)];
             // [("cIn", B false); ("dpIn", N 3)];
             // [("cIn", B false); ("dpIn", N 3)];
         ]
-        let testRun = exec m "Idle" inputVector
+        let ctrlIn = [
+            [("cIn", B true)]; 
+            [("cIn", B true)]; 
+            [("cIn", B true)]; 
+            [("cIn", B false)]; 
+        ]
+        let testRun = exec m "Idle" dpIn ctrlIn
 
-        // List.map (fun l -> printfn "%A\n" l) testRun |> ignore
+        List.map (fun l -> printfn "%A\n" l) testRun |> ignore
         
         // Expr test
         let ctx = Map.empty.Add("x", N 4)

--- a/test/elevator.zorx
+++ b/test/elevator.zorx
@@ -1,0 +1,130 @@
+module Elevator
+    (floorReq: bool in)
+    (floorReqN: int in,
+    readyForInput: bool out) {
+  datapath {
+    currentFloor: int reg,
+    doorState: bool reg, // false=closed, true=open.
+    q1: int reg,
+    q2: int reg,
+    q3: int reg,
+    queuePointer: int status,
+    moveUp: bool status,
+    moveDown: bool status,
+    stay: bool status;
+
+    init {
+      currentFloor := 1;
+      queuePointer := 1;
+    },
+    idle {
+    },
+    setQ1 {
+      q1 := floorReqN;
+      queuePointer := 2;
+    },
+    setQ2 {
+      q2 := floorReqN;
+      queuePointer := 3;
+    },
+    setQ3 {
+      q3 := floorReqN;
+      queuePointer := 4;
+    },
+    // Compare current floor to queue head.
+    compCurrQ1 {
+      moveUp:= currentFloor < q1;
+      moveDown:= currentFloor > q1;
+      stay:= currentFloor == q1;
+    },
+    // Compare current floor to request
+    compCurrFloorReqN {
+      moveUp:= currentFloor < floorReqN;
+      moveDown:= currentFloor > floorReqN;
+      stay:= currentFloor == floorReqN;
+    },
+    moveUp {
+      currentFloor := currentFloor + 1;
+      moveUp:= currentFloor + 1 < q1;
+      moveDown:= currentFloor + 1 > q1;
+      stay:= currentFloor + 1 == q1;
+    },
+    moveDown {
+      currentFloor := currentFloor - 1;
+      moveUp:= currentFloor - 1 < q1;
+      moveDown:= currentFloor - 1 > q1;
+      stay:= currentFloor - 1 == q1;
+    },
+    openDoor {
+      doorState:= true;
+    },
+    closeDoor {
+      doorState := false;
+    },
+    popQueue {
+      queuePointer:= queuePointer - 1;
+      q1 := q2;
+      q2 := q3;
+    }
+  }
+  controller {
+    init [true](init)[
+      readyForInput := false;
+    ]> idle,
+
+    // In this state we know queue is empty.
+    // And door is closed
+    idle [floorReq](setQ1, compCurrFloorReqN)[
+      readyForInput := true;
+    ]> handleMove,
+    idle [!floorReq](idle)[
+      readyForInput := true;
+    ]> idle,
+
+    // Door is closed when here
+    handleMove [moveUp && !floorReq](moveUp)[
+      readyForInput := false;
+    ]> handleDoor,
+    handleMove [moveDown && !floorReq](moveDown)[
+      readyForInput := false;
+    ]> handleDoor,
+
+    // Door is closed when here
+    handleMove [moveUp && floorReq && queuePointer == 2](moveUp, setQ2)[
+      readyForInput := true;
+    ]> handleDoor,
+    handleMove [moveDown && floorReq && queuePointer == 2](moveDown, setQ2)[
+      readyForInput := true;
+    ]> handleDoor,
+    // Door is closed when here
+    handleMove [moveUp && floorReq && queuePointer == 3](moveUp, setQ3)[
+      readyForInput := true;
+    ]> handleDoor,
+    handleMove [moveDown && floorReq && queuePointer == 3](moveDown, setQ3)[
+      readyForInput := true;
+    ]> handleDoor,
+    // Door is closed when here
+    handleMove [moveUp && floorReq && queuePointer > 3](moveUp)[
+      readyForInput := false;
+    ]> handleDoor,
+    handleMove [moveDown && floorReq && queuePointer > 3](moveDown)[
+      readyForInput := false;
+    ]> handleDoor,
+
+    // Door is closed when getting here.
+    handleDoor [stay](openDoor, popQueue)[
+      readyForInput := false;
+    ]> closeDoor,
+    handleDoor [!stay](compCurrQ1)[
+      readyForInput := false;
+    ]> handleMove,
+
+    // Door is open here
+    closeDoor [queuePointer == 1](closeDoor)[
+      readyForInput := true;
+    ]> idle, // Queue just emptied
+    closeDoor [queuePointer > 1](closeDoor, compCurrQ1)[
+      readyForInput := false;
+    ]> handleMove
+  }
+}

--- a/test/elevatorTheoretical.zorx
+++ b/test/elevatorTheoretical.zorx
@@ -1,0 +1,154 @@
+// 3 floors
+// Elevator can move 1 floor pr. cycle.
+// Starts on floor 1, no concept of closed/open door for now.
+module Elevator
+    (reqN: int in, // when in the elevator, a floor is requested
+     callN: int in, // when outside the elevator, the elevator is called
+     callDir: int in) // -1=down, 1=up
+    () {
+    datapath {
+        DoorClosed: bool status,
+        DoorOpened: bool status,
+        ArrivedAtFloor: bool status,
+        Idle {},
+        OpenDoor {
+            DoorOpened := true;
+        },
+        CloseDoor {
+            DoorClosed := true;
+        },
+        StartMotorUp {}, // Symbolic action for now.
+        StartMotorDown {}, // Symbolic action for now.
+        StopMotor {}, // Symbolic action for now.
+        Idle {}
+    }
+    // S = (BS x Floor x ReqQ)
+    controller {
+
+        // E_closing
+        Closing_1_q
+        Closing_1_q1
+        Closing_1_q1up
+        Closing_1_q2
+        Closing_1_q2up
+        Closing_1_q2down
+        Closing_1_q3
+        Closing_1_q3down
+        Closing_2_q
+        Closing_2_q1
+        Closing_2_q1up
+        Closing_2_q2
+        Closing_2_q2up
+        Closing_2_q2down
+        Closing_2_q3
+        Closing_2_q3down
+        Closing_3_q
+        Closing_3_q1
+        Closing_3_q1up
+        Closing_3_q2
+        Closing_3_q2up
+        Closing_3_q2down
+        Closing_3_q3
+        Closing_3_q3down
+
+        Opening_1_q
+        Opening_1_q1
+        Opening_1_q1up
+        Opening_1_q2
+        Opening_1_q2up
+        Opening_1_q2down
+        Opening_1_q3
+        Opening_1_q3down
+        Opening_2_q
+        Opening_2_q1
+        Opening_2_q1up
+        Opening_2_q2
+        Opening_2_q2up
+        Opening_2_q2down
+        Opening_2_q3
+        Opening_2_q3down
+        Opening_3_q
+        Opening_3_q1
+        Opening_3_q1up
+        Opening_3_q2
+        Opening_3_q2up
+        Opening_3_q2down
+        Opening_3_q3
+        Opening_3_q3down
+
+        MovingUp_1_q
+        MovingUp_1_q1
+        MovingUp_1_q1up
+        MovingUp_1_q2
+        MovingUp_1_q2up
+        MovingUp_1_q2down
+        MovingUp_1_q3
+        MovingUp_1_q3down
+        MovingUp_2_q
+        MovingUp_2_q1
+        MovingUp_2_q1up
+        MovingUp_2_q2
+        MovingUp_2_q2up
+        MovingUp_2_q2down
+        MovingUp_2_q3
+        MovingUp_2_q3down
+        MovingUp_3_q
+        MovingUp_3_q1
+        MovingUp_3_q1up
+        MovingUp_3_q2
+        MovingUp_3_q2up
+        MovingUp_3_q2down
+        MovingUp_3_q3
+        MovingUp_3_q3down
+
+        MovingDown_1_q
+        MovingDown_1_q1
+        MovingDown_1_q1up
+        MovingDown_1_q2
+        MovingDown_1_q2up
+        MovingDown_1_q2down
+        MovingDown_1_q3
+        MovingDown_1_q3down
+        MovingDown_2_q
+        MovingDown_2_q1
+        MovingDown_2_q1up
+        MovingDown_2_q2
+        MovingDown_2_q2up
+        MovingDown_2_q2down
+        MovingDown_2_q3
+        MovingDown_2_q3down
+        MovingDown_3_q
+        MovingDown_3_q1
+        MovingDown_3_q1up
+        MovingDown_3_q2
+        MovingDown_3_q2up
+        MovingDown_3_q2down
+        MovingDown_3_q3
+        MovingDown_3_q3down
+
+        Idling_1_q
+        Idling_1_q1
+        Idling_1_q1up
+        Idling_1_q2
+        Idling_1_q2up
+        Idling_1_q2down
+        Idling_1_q3
+        Idling_1_q3down
+        Idling_2_q
+        Idling_2_q1
+        Idling_2_q1up
+        Idling_2_q2
+        Idling_2_q2up
+        Idling_2_q2down
+        Idling_2_q3
+        Idling_2_q3down
+        Idling_3_q
+        Idling_3_q1
+        Idling_3_q1up
+        Idling_3_q2
+        Idling_3_q2up
+        Idling_3_q2down
+        Idling_3_q3
+        Idling_3_q3down
+  }
+}


### PR DESCRIPTION
A module was not able to differentiate datapath and controller declarations. This prevented overlapping variable names, that should be legal.